### PR TITLE
修复物种编号重复和不扩散迁徙到新地块的问题，修复四个其他报错和对应的错误

### DIFF
--- a/backend/app/core/container.py
+++ b/backend/app/core/container.py
@@ -112,7 +112,7 @@ class ServiceContainer(
             else:
                 # 【新增】如果是首次启动（数据库为空或无进度），自动执行一次重置/初始化流程
                 # 检查是否没有任何物种存在，作为判断“全新开局”的依据
-                species_count = self.species_repository.count()
+                species_count = self.species_repository.count_species()
                 if species_count == 0 and (not map_state or map_state.turn_index == 0):
                     logger.info("[容器] 检测到全新数据库，执行自动初始化流程...")
                     self._perform_initial_reset()

--- a/backend/app/services/species/speciation.py
+++ b/backend/app/services/species/speciation.py
@@ -1284,6 +1284,7 @@ class SpeciationService:
                         "average_pressure": average_pressure,  # 【修复】添加压力信息用于fallback
                     },
                     "payload": ai_payload,
+                    "request_turn": turn_index,  # 【关键】用于验证请求是否过期
                 })
         
         if not entries and not self._deferred_requests:
@@ -1406,6 +1407,15 @@ class SpeciationService:
         logger.info(f"[分化] 开始处理 {len(results)} 个AI结果 + {len(background_results)} 个规则结果")
         new_species_events: list[BranchingEvent] = []
         for res, entry in zip(results, active_batch):
+            # 【关键修复】验证请求是否属于当前回合
+            request_turn = entry.get("request_turn", -1)
+            if request_turn != turn_index:
+                logger.warning(
+                    f"[分化跳过-过期] {entry.get('ctx', {}).get('new_code', '?')}: "
+                    f"请求来自回合 {request_turn}，当前回合 {turn_index}，丢弃"
+                )
+                continue
+
             ctx = entry["ctx"]  # 从entry中提取ctx
             
             # 【优化】检查是否需要使用规则fallback
@@ -2627,8 +2637,16 @@ class SpeciationService:
         codes = []
         
         for i in range(num_offspring):
-            letter = letters[i]
-            new_code = f"{parent_code}{letter}"
+            if i < len(letters):
+                letter = letters[i]
+                new_code = f"{parent_code}{letter}"
+            else:
+                # 超过26个子代，添加重复标记
+                repeat_idx = i // len(letters) - 1
+                letter_idx = i % len(letters)
+                letter = letters[letter_idx]
+                repeat = '#' * repeat_idx
+                new_code = f"{parent_code}{repeat}{letter}"
             
             # 如果编码已存在，添加数字后缀
             if new_code in existing_codes:

--- a/backend/app/services/system/divine_progression.py
+++ b/backend/app/services/system/divine_progression.py
@@ -1020,12 +1020,12 @@ class DivineProgressionService:
             return False, "正在蓄力另一个神迹，无法同时执行", {}
         
         # 检查能量（通过外部能量服务）
-        from .divine_energy import divine_energy_service
-        if divine_energy_service.get_state().current < miracle.cost:
-            return False, f"神力不足（需要{miracle.cost}，当前{divine_energy_service.get_state().current}）", {}
+        from .divine_energy import energy_service
+        if energy_service.get_state().current < miracle.cost:
+            return False, f"神力不足（需要{miracle.cost}，当前{energy_service.get_state().current}）", {}
         
         # 消耗能量
-        divine_energy_service.consume(miracle.cost, f"执行神迹「{miracle.name}」")
+        energy_service.spend(miracle.cost, f"执行神迹「{miracle.name}」")
         
         # 设置冷却
         self._state.miracle_state.cooldowns[miracle_id] = miracle.cooldown

--- a/backend/app/simulation/stages.py
+++ b/backend/app/simulation/stages.py
@@ -672,19 +672,14 @@ class FetchSpeciesStage(BaseStage):
         logger.info("获取物种列表...")
         ctx.emit_event("stage", "🧬 获取物种列表", "物种")
         
-        # 【优化】优先使用缓存，回合0或缓存为空时从DB加载
+        # 【关键修复】始终从数据库加载最新物种列表
+        # 原因：分化发生在回合末尾（SpeciationStage），新物种保存到数据库后
+        # 下一回合开始时必须从数据库重新加载，否则 species_batch 不包含新物种
         t0 = time.perf_counter()
         species_cache = get_species_cache()
-        
-        if ctx.turn_index == 0 or species_cache.size == 0:
-            # 首回合或缓存为空，从数据库加载
-            ctx.all_species = species_repository.list_species()
-            species_cache.update(ctx.all_species, ctx.turn_index)
-            timings["db_fetch"] = time.perf_counter() - t0
-        else:
-            # 使用缓存（后续回合的新增/修改会在 upsert 时更新缓存）
-            ctx.all_species = species_cache.get_all()
-            timings["cache_read"] = time.perf_counter() - t0
+        ctx.all_species = species_repository.list_species()
+        species_cache.update(ctx.all_species, ctx.turn_index)
+        timings["db_fetch"] = time.perf_counter() - t0
         
         ctx.species_batch = [sp for sp in ctx.all_species if sp.status == "alive"]
         ctx.extinct_codes = {sp.lineage_code for sp in ctx.all_species if sp.status == "extinct"}

--- a/backend/app/simulation/stages.py
+++ b/backend/app/simulation/stages.py
@@ -2298,6 +2298,12 @@ class SpeciationStage(BaseStage):
             # 原代码只处理 critical_results + focus_results，导致大量 background 物种无法分化
             # 物种分化不需要 AI 做筛选决策，只需要 AI 生成新物种描述，所以处理全部物种是安全的
             
+
+            # 【修复】从数据库获取所有已存在的物种编号，避免重复
+            from ..repositories.species_repository import species_repository
+            existing_codes = {sp.lineage_code for sp in species_repository.list_species()}
+            logger.debug(f"[分化] 数据库中已有 {len(existing_codes)} 个物种编号")
+
             # 【心跳回调】将 ctx.emit_event 包装为 stream_callback，用于 AI 调用心跳
             # 【修复】接收 event_type 和 category，正确传递事件类型
             def speciation_stream_callback(event_type: str, message: str, category: str = "AI"):
@@ -2306,7 +2312,7 @@ class SpeciationStage(BaseStage):
             ctx.branching_events = await asyncio.wait_for(
                 engine.speciation.process_async(
                     mortality_results=ctx.combined_results,  # 【修复】使用所有物种
-                    existing_codes={s.lineage_code for s in ctx.species_batch},
+                    existing_codes=existing_codes,
                     average_pressure=sum(ctx.modifiers.values()) / (len(ctx.modifiers) or 1),
                     turn_index=ctx.turn_index,
                     map_changes=ctx.map_changes,

--- a/backend/app/simulation/tensor_stages.py
+++ b/backend/app/simulation/tensor_stages.py
@@ -163,7 +163,6 @@ class TensorStateInitStage(BaseStage):
 
         # 构建 tile_id -> (y, x) 映射
         tile_coords = {}
-        coord_to_tile_id = {}
 
         if all_tiles:
             def _classify_biome(biome: str) -> tuple[float, float, float]:
@@ -199,7 +198,6 @@ class TensorStateInitStage(BaseStage):
                     env[5, r, c] = sea_flag
                     env[6, r, c] = coast_flag
                     tile_coords[tile.id] = (r, c)
-                    coord_to_tile_id[(r, c)] = tile.id
         else:
             # 默认环境：温带陆地
             env[0, :, :] = 0.4  # 温度
@@ -312,7 +310,7 @@ class TensorStateInitStage(BaseStage):
             env=env,
             pop=pop,
             species_params=species_params,
-            masks={"tile_ids": tile_id_grid, "coord_to_tile_id": coord_to_tile_id},
+            masks={"tile_ids": tile_id_grid},
             species_map=species_map,
         )
         

--- a/backend/app/tensor/ecology.py
+++ b/backend/app/tensor/ecology.py
@@ -1539,7 +1539,7 @@ def extract_species_params(
     """
     S = len(species_map)
     params = np.zeros((S, 8), dtype=np.float32)
-    
+    logger.info(f"提取物种参数矩阵，物种数量：{len(species_list)}，张量化物种数量：{S}")
     for species in species_list:
         lineage = species.lineage_code
         if lineage not in species_map:

--- a/backend/app/tensor/ecology.py
+++ b/backend/app/tensor/ecology.py
@@ -470,8 +470,8 @@ class TensorEcologyEngine:
             cfg.base_diffusion_rate * mean_diffusion_scale
         )
         
-        logger.warning(
-            f"[DEBUG] turn={turn_index}, "
+        logger.debug(
+            f"turn={turn_index}, "
             f"pop_nonzero_tiles={(pop > 0).any(axis=0).sum()}, "
             f"dispersal_iterations={dispersal_iterations}, "
             f"diffusion_rate={adjusted_diffusion_rate:.4f}"
@@ -495,8 +495,8 @@ class TensorEcologyEngine:
         
         metrics.dispersal_time_ms = (time.perf_counter() - t0) * 1000
         
-        logger.warning(
-            f"[DEBUG] 扩散后新增地块: {((pop_after_dispersal > 0).any(axis=0).sum() - (pop_after_death > 0).any(axis=0).sum())}"
+        logger.info(
+            f"扩散后地块数: {((pop_after_dispersal > 0).any(axis=0).sum())}, "
         )
 
         # === 阶段4：迁徙计算 ===
@@ -518,6 +518,8 @@ class TensorEcologyEngine:
         )
         metrics.migration_time_ms = (time.perf_counter() - t0) * 1000
         metrics.migrating_species = len(migrated)
+
+        logger.info(f"迁徙后地块数: {((pop_after_migration > 0).any(axis=0).sum())}, 迁徙物种数: {len(migrated)}")
         
         # === 阶段5：繁殖计算 ===
         # 【v3.1】使用缓冲后的 birth_scale + 压力-繁殖反相扣 + 容量归一
@@ -555,11 +557,39 @@ class TensorEcologyEngine:
         # 【v3.1 缓冲6】防止单步爆炸或瞬灭
         # 对每个格子的净变化设置 [-max_decline, +max_growth] 比例上限
         net_change = final_pop - pop
-        max_growth = pop * cfg.max_net_growth_ratio
-        max_decline = pop * cfg.max_net_decline_ratio
+        
+        # 【关键修复】对于已有种群的地块，使用比例钳制
+        # 对于新地块（原种群为0），使用绝对值钳制
+        has_pop_mask = pop > 0
+        
+        # 已有种群的地块：按比例钳制
+        max_growth_existing = pop * cfg.max_net_growth_ratio
+        max_decline_existing = pop * cfg.max_net_decline_ratio
+        
+        # 新地块（原种群为0）：允许合理的初始种群
+        # 使用邻居平均值或全局平均值作为参考
+        pop_per_species = pop.sum(axis=(1, 2), keepdims=True) / np.maximum((pop > 0).sum(axis=(1, 2), keepdims=True), 1)
+        # 新地块的最大增长 = 该物种平均每地块种群的 max_net_growth_ratio
+        # 这允许扩散/迁徙建立新据点，但不会爆炸
+        max_growth_new = pop_per_species * cfg.max_net_growth_ratio * np.ones_like(pop)
+        # 新地块没有种群，所以 decline 为 0
+        max_decline_new = np.zeros_like(pop)
+        
+        # 合并：已有种群用比例钳制，新地块用绝对值钳制
+        max_growth = np.where(has_pop_mask, max_growth_existing, max_growth_new)
+        max_decline = np.where(has_pop_mask, max_decline_existing, max_decline_new)
+        
         
         # 钳制净变化
         clamped_change = np.clip(net_change, -max_decline, max_growth)
+        logger.debug(
+            f"[TensorEcology] 净变化钳制前: 增长={net_change[net_change > 0].sum():.1f}, "
+            f"减少={-net_change[net_change < 0].sum():.1f}, "
+            f"有变化地块={(net_change != 0).any(axis=0).sum()}, "
+            f"钳制后: 增长={clamped_change[clamped_change > 0].sum():.1f}, "
+            f"减少={-clamped_change[clamped_change < 0].sum():.1f}, "
+            f"有变化地块={(clamped_change != 0).any(axis=0).sum()}"
+        )
         
         # 应用钳制后的变化
         final_pop = np.maximum(0.0, pop + clamped_change)
@@ -580,7 +610,9 @@ class TensorEcologyEngine:
             f"[TensorEcology] 完成: {S}物种, {H}x{W}地图, "
             f"耗时={metrics.total_time_ms:.1f}ms, 后端={metrics.backend}, "
             f"平均死亡率={metrics.avg_mortality_rate:.1%}, "
-            f"特质系统={'启用' if use_trait_system else '禁用'}"
+            f"特质系统={'启用' if use_trait_system else '禁用'}, "
+            f"最终地块数: {((final_pop > 0).any(axis=0).sum())}, "
+            f"总人口: {final_pop.sum():.1f}"
         )
         
         return EcologyResult(

--- a/backend/app/tensor/ecology.py
+++ b/backend/app/tensor/ecology.py
@@ -470,6 +470,13 @@ class TensorEcologyEngine:
             cfg.base_diffusion_rate * mean_diffusion_scale
         )
         
+        logger.warning(
+            f"[DEBUG] turn={turn_index}, "
+            f"pop_nonzero_tiles={(pop > 0).any(axis=0).sum()}, "
+            f"dispersal_iterations={dispersal_iterations}, "
+            f"diffusion_rate={adjusted_diffusion_rate:.4f}"
+        )
+        
         pop_after_dispersal = pop_after_death.copy()
         for disp_iter in range(dispersal_iterations):
             if use_trait_system:
@@ -488,6 +495,10 @@ class TensorEcologyEngine:
         
         metrics.dispersal_time_ms = (time.perf_counter() - t0) * 1000
         
+        logger.warning(
+            f"[DEBUG] 扩散后新增地块: {((pop_after_dispersal > 0).any(axis=0).sum() - (pop_after_death > 0).any(axis=0).sum())}"
+        )
+
         # === 阶段4：迁徙计算 ===
         t0 = time.perf_counter()
         # 提取每个物种的平均死亡率作为迁徙压力信号 - 向量化

--- a/backend/app/tensor/taichi_hybrid_kernels.py
+++ b/backend/app/tensor/taichi_hybrid_kernels.py
@@ -2035,8 +2035,6 @@ def _precompile_all_kernels():
         logger.warning(f"[Taichi] 内核预编译失败（将在首次使用时编译）: {e}")
 
 
-# 在模块加载时预编译
-_precompile_all_kernels()
 
 
 # ============================================================================
@@ -3385,4 +3383,5 @@ def kernel_trait_mortality_v2(
         
         result[s, i, j] = ti.max(0.02, ti.min(0.95, total_mortality))
 
-
+# 在模块加载时预编译
+_precompile_all_kernels()


### PR DESCRIPTION
## 1.修复神力系统能量调用错误导致神力系统无法使用的问题
`divine_energy_service`已经不存在，但是调用时没有相应更改导致报错，修改为正确的就不报错了。
这个问题导致了使用“神力”中的“神迹”时无法使用。
这个问题还导致了discord中有人反馈的“点下一回合只有这个，左边没有能选中的东西”
<img width="1168" height="792" alt="image" src="https://github.com/user-attachments/assets/2af10a1b-92f5-4b47-9571-0733e712ba91" />
修复后恢复正常：
<img width="1907" height="873" alt="image" src="https://github.com/user-attachments/assets/41eb4dca-7358-4803-b701-034e3b41ba47" />

## 2.修复物种计数函数调用错误导致的“恢复回合数或自动初始化失败”
### 日志报错
```txt
[WARNING] app.core.container: [容器] 恢复回合数或自动初始化失败: 'SpeciesRepository' object has no attribute 'count'
```
### 解决
与1.类似，`count()`已经不存在，应改为`count_species()`

## 3.修复了内共生因为返回类型不是字典无法解析而固定失败的问题
### 日志报错
```python
[ERROR] app.services.species.speciation: [内共生失败] AI调用出错: 'dict' object has no attribute 'strip'
```
### 修复
内共生这里实际接收到的是字符串，应该尝试解析 JSON，再作为字典处理

## 4.修复启动时内核预编译失败的问题
### 日志报错
```txt
[WARNING] app.tensor.taichi_hybrid_kernels: [Taichi] 内核预编译失败（将在首次使用时编译）: name 'kernel_advanced_diffusion_v2' is not defined
```
### 修复
`_precompile_all_kernels()`在定义后立刻就调用，`kernel_advanced_diffusion_v2`等其他模块还没有定义，改为放在文件最后调用

## 5.修复物种编号重复的问题
### 现象
我发现在运行中经常会重复分化物种，比如已经有编号A1a的某个物种了，却又分化了一个不同的编号为A1a的物种，并且这些重复的物种都不会分化，甚至某些情况下已经有了许多物种，但是分化的时候却显示只有初始的3个物种。
### 尝试修复
于是尝试让AI修复这个问题，在物种分化时先试用数据库中的完整物种列表，并刷新缓存。之后解决了上面的错误现象，可以正常分化。后来尝试修复扩散问题是发现读取栖息地是列表也不完整，于是**获取物种列表时不再从缓存加载，用部分速度确保游戏可以继续进行。**

### 非常少见的副作用
```txt
[ERROR] app.simulation.pipeline: [Pipeline] 阶段 '统一张量生态计算' 执行失败: index 43 is out of bounds for axis 0 with size 43
```
### 副作用修复
明明按日志来说确实循环了44次，但是`species_map`长度却是43，与`species_list`的44不一致导致，仔细查看日志和调试发现有其中一个物种重复编号。因为修改后每回合`species_list`会同步数据库，把发出请求但是超时没有收到的物种编号去掉，在下一回合收到时如果下一回合恰好有重复的新分化物种时，就会发生这个问题。
上一回合超时的应该直接在接收后丢弃掉，因为即使编码不重复了还会有各种其他错误，比如
```txt
[基于地块分化] 霜洋厚膜虫 继承了 68/68 个地块 (种群:0, 地理隔离分化)
```
就明显是父代的栖息地还是按照上回合的68而不是这回合的101
于是在发送时标记当前的`turn_index`，然后在接收时检验`turn_index`是否是当前回合，如果不是则直接丢弃，**成功解决副作用**。

## 6. 修复无法扩散迁徙到新地块的问题
### 现象
我发现在第一回合会改变一下物种栖息地，之后就一直不变化了
### 栖息地读取修复
经过调试发现`habitats`属性全是空的，实际使用的都是按规则选择的默认分布，于是改为从数据库读取栖息地
### 变化钳制修复
```txt
[WARNING] app.tensor.ecology: [DEBUG] turn=2, pop_nonzero_tiles=7, dispersal_iterations=1, diffusion_rate=0.2820
[WARNING] app.tensor.ecology: [DEBUG] 扩散后地块数: 23, 
[INFO] app.tensor.ecology: [DEBUG] 迁徙后地块数: 348, 迁徙物种数: 8
[INFO] app.tensor.ecology: [DEBUG] 繁殖后地块数: 348
[INFO] app.tensor.ecology: [DEBUG] 竞争后地块数: 348
[INFO] app.tensor.ecology: [DEBUG] 净变化钳制前: 增长=13661478.0, 减少=76456504.0, 地块变化=478,钳制后: 增长=0.0, 减少=47137900.0, 地块变化=21
[INFO] app.tensor.ecology: [DEBUG] 最终地块数: 7, 总人口: 31425260.0
```
发现扩散和迁徙在正常扩展地块，但是净变化钳制却让钳制后一块地也不增加
问题代码：
```python
        max_growth = pop * cfg.max_net_growth_ratio
        max_decline = pop * cfg.max_net_decline_ratio
```
问题：对于 原本为 0 的地块（`pop[s, r, c] == 0`）：

```python
max_growth = 0 * 0.6 = 0
max_decline = 0 * 0.6 = 0
clamped_change = np.clip(positive_value, 0, 0) = 0
```
这意味着 所有新扩散/迁徙到的地块的增长都被钳制为 0！因此改为对于新地块（原种群为0），使用绝对值钳制，已有种群的地块用原来的方法。